### PR TITLE
Add law PJL14-0058, fix orderLetter regex and UnicodeDecodeError

### DIFF
--- a/duralex/alinea_parser.py
+++ b/duralex/alinea_parser.py
@@ -557,7 +557,7 @@ def parse_header3_definition(tokens, i, parent):
     debug(parent, tokens, i, 'parse_header3_definition')
 
     # un {orderLetter}
-    if tokens[i].lower() == u'un' and re.compile(u'[a-z]').match(tokens[i + 2]):
+    if tokens[i].lower() == u'un' and re.compile(u'[a-z]$').match(tokens[i + 2]):
         node = create_node(parent, {
             'type': 'header3',
             'order': ord(str(tokens[i + 2])) - ord('a') + 1,
@@ -569,8 +569,8 @@ def parse_header3_definition(tokens, i, parent):
             i = alinea_lexer.skip_to_quote_start(tokens, i + 4)
             i = parse_quote(tokens, i, node)
     # des {orderLetter} à {orderLetter}
-    elif (tokens[i].lower() == u'des' and re.compile(u'[a-z]').match(tokens[i + 2])
-        and tokens[i + 4] == u'à' and re.compile(u'[a-z]').match(tokens[i + 6])):
+    elif (tokens[i].lower() == u'des' and re.compile(u'[a-z]$').match(tokens[i + 2])
+        and tokens[i + 4] == u'à' and re.compile(u'[a-z]$').match(tokens[i + 6])):
         start = ord(str(tokens[i + 2])) - ord('a') + 1
         end = ord(str(tokens[i + 6])) - ord('a') + 1
         i += 8
@@ -1133,7 +1133,7 @@ def parse_header3_reference(tokens, i, parent):
     # le {orderLetter} ({articlePartRef})
     # du {orderLetter} ({articlePartRef})
     # au {orderLetter} ({articlePartRef})
-    if tokens[i].lower() in [u'le', u'du', u'au'] and re.compile(u'[a-z]').match(tokens[i + 2]):
+    if tokens[i].lower() in [u'le', u'du', u'au'] and re.compile(u'[a-z]$').match(tokens[i + 2]):
         node['order'] = ord(str(tokens[i + 2])) - ord('a') + 1
         i += 4
         i = parse_multiplicative_adverb(tokens, i, node)
@@ -1705,7 +1705,13 @@ def parse_json_article(data, parent):
 
 def parse_json_alineas(data, parent):
     text = alinea_lexer.TOKEN_NEW_LINE.join(value for key, value in list(iter(sorted(data.iteritems()))))
-    parent['content'] = text.decode('utf-8')
+    try:
+        parent['content'] = text.decode('utf-8')
+    except:
+        try:
+            parent['content'] = text.decode('iso-8859-1')
+        except:
+            parent['content'] = text
     return parse_alineas(text, parent)
 
 def parse_alineas(data, parent):

--- a/tests/input/ppl14-0058.json
+++ b/tests/input/ppl14-0058.json
@@ -1,0 +1,59 @@
+{
+  "articles": [
+    {
+      "alineas": {
+        "001": "L'article L. 3421-1 du code de la santé publique est ainsi modifié :",
+        "002": "1° Le premier alinéa est complété par une phrase ainsi rédigée :",
+        "003": "\"Toutefois, sous réserve des dispositions du troisième alinéa, la première infraction constatée est punie de l'amende prévue pour les contraventions de la troisième classe. \" ;",
+        "004": "2° Au deuxième alinéa, les mots : \" de ce délit \" sont remplacés par les mots : \" du délit prévu au premier alinéa \"."
+      },
+      "order": 1,
+      "statut": "none",
+      "titre": "1er",
+      "type": "article"
+    },
+    {
+      "alineas": {
+        "001": "Après l'article L. 3421-1 du code de la santé publique, il est inséré un article L. 3421-1-1 ainsi rédigé :",
+        "002": "\"Art. L. 3421-1-1. - Dans le cas prévu à la seconde phrase du premier alinéa de l'article L. 3421-1, la contravention est accompagnée des coordonnées des centres spécialisés de soins aux toxicomanes les plus proches. \""
+      },
+      "order": 2,
+      "statut": "nouveau",
+      "titre": "1er bis",
+      "type": "article"
+    },
+    {
+      "alineas": {
+        "001": "Au second alinéa de l'article L. 3421-2 du code de la santé publique, les mots : \" lorsque le délit a été constaté \" sont remplacés par les mots : \" lorsque l'infraction a été constatée \"."
+      },
+      "order": 3,
+      "statut": "none",
+      "titre": "2",
+      "type": "article"
+    },
+    {
+      "alineas": {
+        "001": "Au début du premier alinéa de l'article L. 3421-4 du code de la santé publique, les mots : \" La provocation au délit prévu \" sont remplacés par les mots : \" La provocation à l'infraction prévue \"."
+      },
+      "order": 4,
+      "statut": "none",
+      "titre": "3",
+      "type": "article"
+    },
+    {
+      "alineas": {
+        "001": "Le conseil communal ou intercommunal de sécurité et de prévention de la délinquance est informé du nombre d'infractions constatées pour le premier usage de stupéfiants."
+      },
+      "order": 5,
+      "statut": "nouveau",
+      "titre": "4",
+      "type": "article"
+    }
+  ],
+  "definitive": false,
+  "expose": "",
+  "id": 58,
+  "legislature": 14,
+  "type": "proposition de loi",
+  "url": "http://www.assemblee-nationale.fr/14/propositions/pion0058.asp"
+}

--- a/tests/output/ppl14-0058.json
+++ b/tests/output/ppl14-0058.json
@@ -1,0 +1,284 @@
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "type": "quote", 
+                          "words": "Toutefois, sous réserve des dispositions du troisième alinéa, la première infraction constatée est punie de l'amende prévue pour les contraventions de la troisième classe."
+                        }
+                      ], 
+                      "type": "sentence"
+                    }, 
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "order": 1, 
+                              "type": "alinea-reference"
+                            }
+                          ], 
+                          "id": "L. 3421-1", 
+                          "type": "article-reference"
+                        }
+                      ], 
+                      "codeName": "code de la santé publique", 
+                      "type": "code-reference"
+                    }
+                  ], 
+                  "editType": "add", 
+                  "type": "edit"
+                }
+              ], 
+              "order": 1, 
+              "type": "bill-header2"
+            }, 
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "type": "quote", 
+                          "words": "du délit prévu au premier alinéa"
+                        }
+                      ], 
+                      "type": "words"
+                    }, 
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "type": "quote", 
+                                      "words": "de ce délit"
+                                    }
+                                  ], 
+                                  "type": "words-reference"
+                                }
+                              ], 
+                              "order": 2, 
+                              "type": "alinea-reference"
+                            }
+                          ], 
+                          "id": "L. 3421-1", 
+                          "type": "article-reference"
+                        }
+                      ], 
+                      "codeName": "code de la santé publique", 
+                      "type": "code-reference"
+                    }
+                  ], 
+                  "editType": "replace", 
+                  "type": "edit"
+                }
+              ], 
+              "order": 2, 
+              "type": "bill-header2"
+            }
+          ], 
+          "implicit": true, 
+          "order": 1, 
+          "type": "bill-header1"
+        }
+      ], 
+      "content": "L'article L. 3421-1 du code de la santé publique est ainsi modifié :\n1° Le premier alinéa est complété par une phrase ainsi rédigée :\n\"Toutefois, sous réserve des dispositions du troisième alinéa, la première infraction constatée est punie de l'amende prévue pour les contraventions de la troisième classe. \" ;\n2° Au deuxième alinéa, les mots : \" de ce délit \" sont remplacés par les mots : \" du délit prévu au premier alinéa \".", 
+      "isNew": false, 
+      "order": 1, 
+      "type": "article"
+    }, 
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "type": "quote", 
+                      "words": "Dans le cas prévu à la seconde phrase du premier alinéa de l'article L. 3421-1, la contravention est accompagnée des coordonnées des centres spécialisés de soins aux toxicomanes les plus proches."
+                    }
+                  ], 
+                  "id": "L. 3421-1-1", 
+                  "type": "article"
+                }, 
+                {
+                  "children": [
+                    {
+                      "id": "L. 3421-1", 
+                      "position": "after", 
+                      "type": "article-reference"
+                    }
+                  ], 
+                  "codeName": "code de la santé publique", 
+                  "type": "code-reference"
+                }
+              ], 
+              "editType": "add", 
+              "type": "edit"
+            }
+          ], 
+          "implicit": true, 
+          "order": 1, 
+          "type": "bill-header1"
+        }
+      ], 
+      "content": "Après l'article L. 3421-1 du code de la santé publique, il est inséré un article L. 3421-1-1 ainsi rédigé :\n\"Art. L. 3421-1-1. - Dans le cas prévu à la seconde phrase du premier alinéa de l'article L. 3421-1, la contravention est accompagnée des coordonnées des centres spécialisés de soins aux toxicomanes les plus proches. \"", 
+      "isNew": false, 
+      "order": 2, 
+      "type": "article"
+    }, 
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "type": "quote", 
+                      "words": "lorsque l'infraction a été constatée"
+                    }
+                  ], 
+                  "type": "words"
+                }, 
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "type": "quote", 
+                                  "words": "lorsque le délit a été constaté"
+                                }
+                              ], 
+                              "type": "words-reference"
+                            }
+                          ], 
+                          "order": 2, 
+                          "type": "alinea-reference"
+                        }
+                      ], 
+                      "id": "L. 3421-2", 
+                      "type": "article-reference"
+                    }
+                  ], 
+                  "codeName": "code de la santé publique", 
+                  "type": "code-reference"
+                }
+              ], 
+              "editType": "replace", 
+              "type": "edit"
+            }
+          ], 
+          "implicit": true, 
+          "order": 1, 
+          "type": "bill-header1"
+        }
+      ], 
+      "content": "Au second alinéa de l'article L. 3421-2 du code de la santé publique, les mots : \" lorsque le délit a été constaté \" sont remplacés par les mots : \" lorsque l'infraction a été constatée \".", 
+      "isNew": false, 
+      "order": 3, 
+      "type": "article"
+    }, 
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "type": "quote", 
+                      "words": "La provocation à l'infraction prévue"
+                    }
+                  ], 
+                  "type": "words"
+                }, 
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "type": "quote", 
+                                  "words": "La provocation au délit prévu"
+                                }
+                              ], 
+                              "type": "words-reference"
+                            }
+                          ], 
+                          "order": 1, 
+                          "position": "beginning", 
+                          "type": "alinea-reference"
+                        }
+                      ], 
+                      "id": "L. 3421-4", 
+                      "type": "article-reference"
+                    }
+                  ], 
+                  "codeName": "code de la santé publique", 
+                  "type": "code-reference"
+                }
+              ], 
+              "editType": "replace", 
+              "type": "edit"
+            }
+          ], 
+          "implicit": true, 
+          "order": 1, 
+          "type": "bill-header1"
+        }
+      ], 
+      "content": "Au début du premier alinéa de l'article L. 3421-4 du code de la santé publique, les mots : \" La provocation au délit prévu \" sont remplacés par les mots : \" La provocation à l'infraction prévue \".", 
+      "isNew": false, 
+      "order": 4, 
+      "type": "article"
+    }, 
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "content": "Le conseil communal ou intercommunal de sécurité et de prévention de la délinquance est informé du nombre d'infractions constatées pour le premier usage de stupéfiants.", 
+              "type": "raw-content"
+            }
+          ], 
+          "implicit": true, 
+          "order": 1, 
+          "type": "bill-header1"
+        }
+      ], 
+      "content": "Le conseil communal ou intercommunal de sécurité et de prévention de la délinquance est informé du nombre d'infractions constatées pour le premier usage de stupéfiants.", 
+      "isNew": false, 
+      "order": 5, 
+      "type": "article"
+    }
+  ], 
+  "id": 58, 
+  "legislature": 14, 
+  "type": "proposition de loi", 
+  "url": "http://www.assemblee-nationale.fr/14/propositions/pion0058.asp"
+}


### PR DESCRIPTION
Trying to parse [PJL14-0058](http://www.assemblee-nationale.fr/14/propositions/pion0058.asp) used to produce the following crash :

```
> ./duralex --url "http://www.assemblee-nationale.fr/14/propositions/pion0058.asp"
Traceback (most recent call last):
  File "./duralex", line 74, in <module>
    sys.exit(main())
  File "./duralex", line 69, in main
    handle_data(data, args)
  File "./duralex", line 29, in handle_data
    ast = duralex.alinea_parser.parse_json_data(data)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1757, in parse_json_data
    parse_json_articles(data, node)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1687, in parse_json_articles
    parse_json_article(article_data, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1704, in parse_json_article
    parse_json_alineas(data['alineas'], node)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1709, in parse_json_alineas
    return parse_alineas(text, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1713, in parse_alineas
    parse_for_each(parse_bill_header1, tokens, 0, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1671, in parse_for_each
    test = fn(tokens, i, n)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1572, in parse_bill_header1
    i = parse_edit(tokens, i, node)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1280, in parse_edit
    i = parse_reference_list(tokens, i, node)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1495, in parse_reference_list
    i = parse_reference(tokens, i, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1538, in parse_reference
    node
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1511, in parse_one_of
    j = fn(tokens, i, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1221, in parse_article_part_reference
    j = parse_header3_reference(tokens, i, parent)
  File "/home/piouffb/Seafile/Workspace/OpenSource/DuraLex/bin/../duralex/alinea_parser.py", line 1137, in parse_header3_reference
    node['order'] = ord(str(tokens[i + 2])) - ord('a') + 1
TypeError: ord() expected a character, but string of length 7 found
```

Reason for this is that python regex system `re.compile(u'[a-z]')` will match any string starting with a lowercase letter and not only single character strings as wanted when parsing orderLetter. From documentation :
```
If zero or more characters at the beginning of string match the regular expression pattern, return a corresponding MatchObject instance. Return None if the string does not match the pattern; note that this is different from a zero-length match.
```

I'm not a big fan on Python's regex for this kind of behaviour 😕

JSON test files for this law have also been added.

This also fixes #1 